### PR TITLE
Add SMSPLUS-GX Core

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y p7zip-full binutils-mips-linux-gnu build-essential pkgconf python3 git zip wget curl libsdl2-dev emscripten

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+	"name": "EmulatorJS Core Build",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	//"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm",
+	"build": { "dockerfile": "Dockerfile" },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5198],
+	// "portsAttributes": {
+	// 		"5198": {
+	// 			"protocol": "http"
+	// 		}
+	// },
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash /workspaces/build/build_env.sh",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"github.vscode-github-actions",
+				"GitHub.vscode-pull-request-github"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -22,13 +22,13 @@ jobs:
         run: "source ./.emsdk/emsdk_env.sh && bash build.sh"
 
       - name: Zip files
-        run: "zip -r 'EmulatorJS Cores.zip' EmulatorJS/data/cores/*.data"
+        run: "zip -r 'EmulatorJS Cores.zip' ./compile/EmulatorJS/data/cores/*.data"
 
       - name: Generate checksums
         uses: jmgilman/actions-generate-checksum@v1
         with:
           patterns: |
-            EmulatorJS/data/cores/*.data
+            ./compile/EmulatorJS/data/cores/*.data
 
       - name: Get Version
         id: version
@@ -40,6 +40,6 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           gh release create "v$VERSION" --title "Latest Version v$VERSION" --generate-notes
-          gh release upload "v$VERSION" EmulatorJS/data/cores/*.data
+          gh release upload "v$VERSION" ./compile/EmulatorJS/data/cores/*.data
           gh release upload "v$VERSION" "EmulatorJS Cores.zip"
           gh release upload "v$VERSION" "checksum.txt#checksum-256.txt"

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 /*
+!/.devcontainer
 !/.gitignore
 !/build.sh
+!/build_env.sh
 !/LICENSE
 !/emscripten.patch
 !/.github
 !/.github/workflows/compile.yml
-

--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 # build
 A simple script that will download and build the emulatorjs core files
 
-
 This script will download and build most of the available retroarch cores.
 
+**Warning**: Some cores do not compile on ARM based systems (such as M series MacBooks and Raspberry Pi). Use only amd64 based systems to compile.
 
-TODO: List dependencies
+# Set up your build environment
+
+## VSCode and Dev Containers
+This repo contains a devcontainer configuration.
+
+Using docker and VSCode, the repo can be started in a container, where all dependencies are installed for you.
+
+## Local
+To set up the build environment on an Ubuntu/Debian system, run the enclosed ``build_env.sh`` script to install all required components
+
+# Compiling
+Execute the command ``source ./.emsdk/emsdk_env.sh && bash build.sh`` in the repo root to begin compiling.
+
+Compiled assets will be in the ``./compile`` directory.

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 initialPath="$PWD"
+buildPath="$PWD/compile"
 outPath="RetroArch/dist-scripts"
 tempPath="RetroArch/dist-scripts/core-temp"
 
@@ -9,37 +10,42 @@ build() {
     emmake make -f "$makefileName" clean
     emmake make -j$(nproc) -f "$makefileName" platform=emscripten $makefileArg || exit 1
     linkerfilename=( *.bc )
-    mv $linkerfilename "$initialPath/$tempPath/normal/"
+    mv $linkerfilename "$buildPath/$tempPath/normal/"
 }
 buildThreads() {
     rm -f *.bc
     emmake make -f "$makefileName" clean
     emmake make -j$(nproc) -f "$makefileName" platform=emscripten EMULATORJS_THREADS=1 $makefileArg || exit 1
     linkerfilename=( *.bc )
-    mv $linkerfilename "$initialPath/$tempPath/threads/"
+    mv $linkerfilename "$buildPath/$tempPath/threads/"
 }
 buildLegacy() {
     rm -f *.bc
     emmake make -f "$makefileName" clean
     emmake make -j$(nproc) -f "$makefileName" platform=emscripten EMULATORJS_LEGACY=1 $makefileArg || exit 1
     linkerfilename=( *.bc )
-    mv $linkerfilename "$initialPath/$tempPath/legacy/"
+    mv $linkerfilename "$buildPath/$tempPath/legacy/"
 }
 buildThreadsLegacy() {
     rm -f *.bc
     emmake make -f "$makefileName" clean
     emmake make -j$(nproc) -f "$makefileName" platform=emscripten EMULATORJS_THREADS=1 EMULATORJS_LEGACY=1 $makefileArg || exit 1
     linkerfilename=( *.bc )
-    mv $linkerfilename "$initialPath/$tempPath/legacyThreads/"
+    mv $linkerfilename "$buildPath/$tempPath/legacyThreads/"
 }
 
+# create compile directory
+mkdir -p $buildPath
+cd $buildPath
+
+# start pulling sources and compile
 if [ ! -d "RetroArch" ]; then
     git clone "https://github.com/EmulatorJS/RetroArch.git" "RetroArch" || exit 1
 fi
 
 cd "$outPath"
 rm -f *.bc
-cd "$initialPath"
+cd "$buildPath"
 
 rm -fr $tempPath
 mkdir -p $tempPath/
@@ -48,7 +54,7 @@ mkdir -p normal/
 mkdir -p threads/
 mkdir -p legacy/
 mkdir -p legacyThreads/
-cd $initialPath
+cd $buildPath
 
 compileProject() {
     name=$1
@@ -81,7 +87,7 @@ compileProject() {
         fi
     fi
 
-    cd "$initialPath"
+    cd "$buildPath"
 }
 
 if [ ! -d "EmulatorJS" ]; then
@@ -130,6 +136,7 @@ compileProject "vice_x128" "https://github.com/EmulatorJS/vice-libretro.git" "./
 compileProject "vice_xpet" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xpet"
 compileProject "vice_xplus4" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xplus4"
 compileProject "vice_xvic" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xvic"
+# compileProject "smsplus-gx" "https://github.com/libretro/smsplus-gx.git" "./" "Makefile"
 
 cd "RetroArch"
 git pull

--- a/build.sh
+++ b/build.sh
@@ -136,7 +136,7 @@ compileProject "vice_x128" "https://github.com/EmulatorJS/vice-libretro.git" "./
 compileProject "vice_xpet" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xpet"
 compileProject "vice_xplus4" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xplus4"
 compileProject "vice_xvic" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xvic"
-# compileProject "smsplus-gx" "https://github.com/libretro/smsplus-gx.git" "./" "Makefile"
+compileProject "smsplus-gx" "https://github.com/libretro/smsplus-gx.git" "./" "Makefile.libretro"
 
 cd "RetroArch"
 git pull

--- a/build.sh
+++ b/build.sh
@@ -136,7 +136,7 @@ compileProject "vice_x128" "https://github.com/EmulatorJS/vice-libretro.git" "./
 compileProject "vice_xpet" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xpet"
 compileProject "vice_xplus4" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xplus4"
 compileProject "vice_xvic" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xvic"
-compileProject "smsplus-gx" "https://github.com/libretro/smsplus-gx.git" "./" "Makefile.libretro"
+compileProject "smsplus-gx" "https://github.com/EmulatorJS/smsplus-gx" "./" "Makefile.libretro" "" "no" "no"
 
 cd "RetroArch"
 git pull

--- a/build.sh
+++ b/build.sh
@@ -136,7 +136,7 @@ compileProject "vice_x128" "https://github.com/EmulatorJS/vice-libretro.git" "./
 compileProject "vice_xpet" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xpet"
 compileProject "vice_xplus4" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xplus4"
 compileProject "vice_xvic" "https://github.com/EmulatorJS/vice-libretro.git" "./" "Makefile" "EMUTYPE=xvic"
-compileProject "smsplus-gx" "https://github.com/EmulatorJS/smsplus-gx" "./" "Makefile.libretro" "" "no" "no"
+compileProject "smsplus-gx" "https://github.com/EmulatorJS/smsplus-gx" "./" "Makefile.libretro"
 
 cd "RetroArch"
 git pull

--- a/build_env.sh
+++ b/build_env.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+cd /workspaces/build
+git clone https://github.com/emscripten-core/emsdk.git .emsdk
+cd .emsdk
+./emsdk install latest
+./emsdk activate latest
+source ./emsdk_env.sh
+wget https://raw.githubusercontent.com/EmulatorJS/build/main/emscripten.patch
+patch -u -p0 -i ../emscripten.patch
+cd ../


### PR DESCRIPTION
This PR adds:
* the SMSPLUS-GX core (the build script is still pointing to the upstream repo, which will need to be updated)
  * tested working in a local build of EJS
* all builds are now under a compile sub-directory which I found a bit easier to clean up after failed builds
* adds docker devcontainer support, to build a dev environment when used with docker and VS Code