### PR TITLE
Adds defaultWebGL2 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ To add a new core, add a stanza like the below:
         "settings": {
             "mame2003_skip_disclaimer": "enabled",
             "mame2003_skip_warnings": "enabled"
-        }
+        },
+        "defaultWebGL2": false
     },
     "license": "LICENSE.md",
-    "repo": "https://github.com/EmulatorJS/mame2003-libretro"
+    "repo": "https://github.com/EmulatorJS/mame2003-libretro",
+    "branch": "main"
 }
 ```
 
@@ -49,6 +51,7 @@ To add a new core, add a stanza like the below:
 | ``extensions`` | An array of file extensions used by the core |
 | ``license``   | The path to the repo project license file. This path is relative to the root of the repo. |
 | ``repo``      | A link to the project repository |
+| ``branch``    | The git branch to switch to when building |
 | ``makeoptions`` | Settings and options for building the core (see makeoptions table below) |
 | ``options``   | Options to be set by the emulator (see options table below) |
 
@@ -64,3 +67,4 @@ To add a new core, add a stanza like the below:
 | --------- | ---------- |
 | ``file``      | The relative path and file name for the core options file |
 | ``settings``  | A hash table of attributes and their values to write to the core options file |
+| ``defaultWebGL2`` | A boolean value of if WebGL2 should be defaulted to enabled |

--- a/cores.json
+++ b/cores.json
@@ -181,7 +181,9 @@
             "makescript": "Makefile",
             "arguments": []
         },
-        "options": {},
+        "options": {
+            "defaultWebGL2": true
+        },
         "license": "LICENSE",
         "repo": "https://github.com/EmulatorJS/mupen64plus-libretro-nx"
     },
@@ -193,7 +195,9 @@
             "buildpath": "./",
             "makescript": "Makefile"
         },
-        "options": {},
+        "options": {
+            "defaultWebGL2": true
+        },
         "license": "LICENSE",
         "repo": "https://github.com/EmulatorJS/melonDS"
     },
@@ -205,7 +209,9 @@
             "buildpath": "./desmume",
             "makescript": "Makefile.libretro"
         },
-        "options": {},
+        "options": {
+            "defaultWebGL2": true
+        },
         "license": "",
         "repo": "https://github.com/EmulatorJS/desmume2015"
     },
@@ -217,7 +223,9 @@
             "buildpath": "./desmume/src/frontend/libretro",
             "makescript": "Makefile.libretro"
         },
-        "options": {},
+        "options": {
+            "defaultWebGL2": true
+        },
         "license": "",
         "repo": "https://github.com/EmulatorJS/desmume"
     },
@@ -349,7 +357,9 @@
             "buildpath": "./",
             "makescript": "Makefile.libretro"
         },
-        "options": {},
+        "options": {
+            "defaultWebGL2": true
+        },
         "license": "COPYING",
         "repo": "https://github.com/EmulatorJS/pcsx_rearmed"
     },
@@ -385,7 +395,9 @@
             "buildpath": "./",
             "makescript": "Makefile"
         },
-        "options": {},
+        "options": {
+            "defaultWebGL2": true
+        },
         "license": "COPYING",
         "repo": "https://github.com/EmulatorJS/beetle-psx-libretro"
     },
@@ -462,7 +474,9 @@
             "buildpath": "./",
             "makescript": "Makefile"
         },
-        "options": {},
+        "options": {
+            "defaultWebGL2": true
+        },
         "license": "",
         "repo": "https://github.com/EmulatorJS/parallel-n64"
     },

--- a/cores.json
+++ b/cores.json
@@ -474,9 +474,7 @@
             "buildpath": "./",
             "makescript": "Makefile"
         },
-        "options": {
-            "defaultWebGL2": true
-        },
+        "options": {},
         "license": "",
         "repo": "https://github.com/EmulatorJS/parallel-n64"
     },


### PR DESCRIPTION
Adds an option to the cores.json file that will tell EJS if WebGL2 should be enabled by default.

The option has been added to the following cores:
* mupen64plus_next
* melonds
* desmume2015
* desmume
* pcsx_rearmed
* mednafen_psx_hw
* parallel_n64

A stanza should look like this:
```json
{
    "name": "parallel_n64",
    "extensions": [ "n64", "v64", "z64", "bin", "u1", "ndd", "gb" ],
    "makeoptions": {
        "arguments": [],
        "buildpath": "./",
        "makescript": "Makefile"
    },
    "options": {
        "defaultWebGL2": true
    },
    "license": "",
    "repo": "https://github.com/EmulatorJS/parallel-n64"
}
```