### PR TITLE
Writes the core options to the core report json files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -128,6 +128,7 @@ for row in $(jq -r '.[] | @base64' ../cores.json); do
     buildpath=`echo $(_jq '.') | jq -r '.makeoptions.buildpath'`
     makescript=`echo $(_jq '.') | jq -r '.makeoptions.makescript'`
     arguments=`echo $(_jq '.') | jq -r '.makeoptions.arguments[] | @base64'`
+    options=`echo $(_jq '.') | jq -r '.options'`
 
     argumentstring=""
     for rowarg in $(echo "${arguments}"); do
@@ -196,7 +197,7 @@ for row in $(jq -r '.[] | @base64' ../cores.json); do
     
     # write report to report file
     endTime=`date -u -Is`
-    reportString="{ \"core\": \"$name\", \"buildStart\": \"$startTime\", \"buildEnd\": \"$endTime\" }"
+    reportString="{ \"core\": \"$name\", \"buildStart\": \"$startTime\", \"buildEnd\": \"$endTime\", \"options\": $options }"
     buildReportFile="$buildReport/$name.json"
     echo $reportString > $buildReportFile
 done


### PR DESCRIPTION
Writes core options to the core report json files. See samples:
```json
{ "core": "mame2003", "buildStart": "2024-07-31T14:42:51+00:00", "buildEnd": "2024-07-31T14:42:51+00:00", "options": { "file": "MAME 2003 (0.78)/MAME 2003 (0.78).opt", "settings": { "mame2003_skip_disclaimer": "enabled", "mame2003_skip_warnings": "enabled" } } }
```

```json
{ "core": "melonds", "buildStart": "2024-07-31T14:42:55+00:00", "buildEnd": "2024-07-31T14:42:55+00:00", "options": { "defaultWebGL2": true, "supportsMouse": true } }
```