### PR TITLE
Add a core status attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ To add a new core, add a stanza like the below:
 | ``branch``    | The git branch to switch to when building |
 | ``makeoptions`` | Settings and options for building the core (see makeoptions table below) |
 | ``options``   | Options to be set by the emulator (see options table below) |
+| ``status``    | ``0`` or not set = ``stable``<br />``1`` = ``beta``<br />``2`` = ``experimental``<br />``3`` = ``don't build`` - the build script will skip building the core |
 
 ### makeoptions
 | Attribute | Definition |

--- a/build.sh
+++ b/build.sh
@@ -201,7 +201,7 @@ for row in $(jq -r '.[] | @base64' ../cores.json); do
         
         # write report to report file
         endTime=`date -u -Is`
-        reportString="{ \"core\": \"$name\", \"buildStart\": \"$startTime\", \"buildEnd\": \"$endTime\", \"options\": $options }"
+        reportString="{ \"core\": \"$name\", \"buildStart\": \"$startTime\", \"buildEnd\": \"$endTime\", \"status\": $status, \"options\": $options }"
         buildReportFile="$buildReport/$name.json"
         echo $reportString > $buildReportFile
 

--- a/cores.json
+++ b/cores.json
@@ -535,7 +535,8 @@
         },
         "options": {},
         "license": "LICENSE",
-        "repo": "https://github.com/libretro/81-libretro"
+        "repo": "https://github.com/libretro/81-libretro",
+        "status": 2
     },
     {
         "name": "fuse",
@@ -547,7 +548,8 @@
         },
         "options": {},
         "license": "LICENSE",
-        "repo": "https://github.com/libretro/fuse-libretro"
+        "repo": "https://github.com/libretro/fuse-libretro",
+        "status": 2
     },
     {
         "name": "cap32",
@@ -559,7 +561,8 @@
         },
         "options": {},
         "license": "",
-        "repo": "https://github.com/libretro/libretro-cap32"
+        "repo": "https://github.com/libretro/libretro-cap32",
+        "status": 2
     },
     {
         "name": "crocods",
@@ -571,6 +574,7 @@
         },
         "options": {},
         "license": "LICENSE",
-        "repo": "https://github.com/libretro/libretro-crocods"
+        "repo": "https://github.com/libretro/libretro-crocods",
+        "status": 2
     }
 ]


### PR DESCRIPTION
Adds an attribute called "status". The intention is to allow EJS to display the state of the build to manage user expectations if a core is still in test or not completely functional.

Status can have one of the following values:

* ``0`` or not set = ``stable``
* ``1`` = ``beta``
* ``2`` = ``experimental``
* ``3`` = ``don't build`` - the build script will skip building the core