### PR TITLE
Add same_cdi core

### DIFF
--- a/cores.json
+++ b/cores.json
@@ -648,5 +648,17 @@
         "save": false,
         "license": "LICENSE.TXT",
         "repo": "https://github.com/EmulatorJS/ppsspp"
+    },
+    {
+        "name": "same_cdi",
+        "extensions": [ "chd", "iso", "cue" ],
+        "makeoptions": {
+            "buildpath": "./",
+            "makescript": "Makefile.libretro",
+            "arguments": []
+        },
+        "options": {},
+        "license": "COPYING",
+        "repo": "https://github.com/EmulatorJS/same_cdi"
     }
 ]


### PR DESCRIPTION
A few quirks to know:
- The documentation does not mention it but it seems that the required _cdimono1.zip_ bios file needs to have an intermediate _cdimono1_ folder inside it with the actual bios files under it.
- The core claims it supports bin/cue and iso but I have had issues booting those, chd format loads fine though.