### PR TITLE
Add blueMSX core to the build system

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -413,6 +413,20 @@ for row in $(jq -r '.[] | @base64' ../cores.json); do
             cp EmulatorJS/data/cores/$name-thread-legacy-wasm.data $outputPath
         fi
 
+        # blueMSX requires Machines/ and Databases/ at runtime. The C-BIOS
+        # variants in these directories use freely redistributable ROMs so
+        # they can be packaged directly into the core archive.
+        if [ "$name" = "bluemsx" ]; then
+            echo "Adding system files (Machines + Databases) to bluemsx core archives..."
+            cd "$compileStartPath/$name/system/bluemsx"
+            for datafile in "$compileStartPath/EmulatorJS/data/cores/bluemsx"*.data; do
+                if [ -f "$datafile" ]; then
+                    7z a -t7z "$datafile" ./Machines ./Databases
+                fi
+            done
+            cd "$compileStartPath"
+        fi
+
         # create zip file containing the core data files
         cd EmulatorJS/data/cores
         zip $outputPath/$name.zip $name-thread*wasm.data

--- a/cores.json
+++ b/cores.json
@@ -1255,5 +1255,24 @@
         },
         "license": "license.txt",
         "repo": "https://github.com/EmulatorJS/azahar"
+    },
+    {
+        "name": "bluemsx",
+        "extensions": [
+            "rom", "ri", "mx1", "mx2", "dsk", "col",
+            "sg", "sc", "sf", "cas", "m3u"
+        ],
+        "makeoptions": {
+            "buildpath": "./",
+            "makescript": "Makefile.libretro",
+            "arguments": []
+        },
+        "options": {
+            "supportsMouse": true,
+            "useKeyboard": true
+        },
+        "save": "srm",
+        "license": "license.txt",
+        "repo": "https://github.com/EmulatorJS/blueMSX-libretro"
     }
 ]


### PR DESCRIPTION
- Core entry in cores.json with 11 supported extensions, mouse and keyboard support, save state compatibility (SRM).
- Build hook packages the Machines/ and Databases/ directories containing freely redistributable C-BIOS ROMs into the core .data archive so they are available at runtime without a separate BIOS download.